### PR TITLE
enable limiting size of exported feed

### DIFF
--- a/scripts/export_sms_feed.sh
+++ b/scripts/export_sms_feed.sh
@@ -14,7 +14,9 @@
 #
 # Environment variables:
 #
-#	SMS_SSH       SSH client to use instead of "ssh".
+#	SMS_SSH               SSH client to use instead of "ssh".
+#	EXTRA_GENMRSS_OPTS    Extra options appended to sms2jwplayer genmrss
+#	                      command
 set -e
 
 HOST=$1
@@ -86,7 +88,8 @@ COPY (
 EOL
 
 msg "-- Generating feed"
-sms2jwplayer -v genmrss --base="${BASE}" --output=feed.rss sms_export.csv
+sms2jwplayer -v genmrss --base="${BASE}" --output=feed.rss \
+	${EXTRA_GENMRSS_OPTS} sms_export.csv
 
 popd >/dev/null
 msg "-- Writing feed to '${FEED}'"

--- a/sms2jwplayer/__init__.py
+++ b/sms2jwplayer/__init__.py
@@ -4,7 +4,7 @@ Tool to support bulk import of University of Cambridge SMS into JWPlayer.
 Usage:
     sms2jwplayer (-h | --help)
     sms2jwplayer genmrss [--verbose] --base=URL [--strip-leading=N]
-        [--output=FILE] <csv>
+        [--output=FILE] [--limit=NUMBER] [--offset=NUMBER] <csv>
     sms2jwplayer fetch [--verbose] [--base-name=NAME]
     sms2jwplayer genupdatejob [--verbose] [--strip-leading=N]
         [--output=FILE] <csv> <metadata>...
@@ -31,6 +31,10 @@ Options:
 
     --base-name=NAME    Base of filename used to save results to.
                         [default: videos_]
+
+    --limit=NUMBER      Limit feed to last NUMBER most updated videos. [default: 1000]
+    --offset=NUMBER     Start feed at NUMBER-th most recently updated. This index is 0-based
+                        [default: 0]
 
 Sub commands:
 

--- a/sms2jwplayer/genmrss.py
+++ b/sms2jwplayer/genmrss.py
@@ -63,6 +63,19 @@ def main(opts):
         items = smscsv.load(f)
     LOG.info('Loaded %s item(s)', len(items))
 
+    # Sort items by descending last_updated_at
+    items.sort(key=lambda item: item.last_updated_at)
+    items.reverse()
+
+    limit = int(opts['--limit'])
+    offset = int(opts['--offset'])
+    items = items[offset:limit+offset]
+    LOG.info('Limited feed to {} item(s) starting from offset {}'.format(limit, offset))
+    LOG.info('Feed truncated to {} items(s)'.format(len(items)))
+    if len(items) > 0:
+        LOG.info('Most recent last updated: {}'.format(items[0].last_updated_at))
+        LOG.info('Least recent last updated: {}'.format(items[-1].last_updated_at))
+
     def url(item):
         """Return the URL for an item."""
         path_items = item.filename.strip('/').split('/')

--- a/sms2jwplayer/test/data/export_example.csv
+++ b/sms2jwplayer/test/data/export_example.csv
@@ -1,3 +1,3 @@
 media_id,clip_id,format,filename,created_at,title,description,collection_id,instid,aspect_ratio,creator,in_dspace,publisher,copyright,language,keywords,visibility,acl,screencast,image_id,dspace_path,featured,branding,last_updated_at,updated_by,downloadable,withdrawn,abstract,priority
-8,997042,archive-h264,/archive/8/997042.mp4,2007-09-04 19:11:47+01,foo,foobar,12,SB,4x3,spqr2,t,,,,,world,,f,,123/456,t,f,2007-09-04 19:11:47+01,spqr2,f,,,1
+8,997042,archive-h264,/archive/8/997042.mp4,2007-09-04 19:11:47+01,foo,foobar,12,SB,4x3,spqr2,t,,,,,world,,f,,123/456,t,f,2007-09-04 19:11:48+01,spqr2,f,,,1
 8,13264,audio,/archive/8/13264.aif,2007-09-04 19:11:47+01,some title,and some description,12,SB,16x9,spqr2,f,,,,,world,,f,,123/456,t,f,2007-09-04 19:11:47+01,spqr2,f,,,1


### PR DESCRIPTION
JWPlatform no longer support importing feeds of greater than 1000 items. Teach genmrss how to truncate the list of items it uses to form the feed. When merged, the generated MRSS feed should now be limited to 1000 items.

We may want to generate 2 (or 3) feeds for the last 0-1000, 1000-2000, ... modified items to make sure we catch everything.