### PR TITLE
added media:thumbnail to the MRSS feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ __pycache__
 .eggs
 .cache
 .coverage
+.idea
 build
+venv

--- a/scripts/export_sms_feed.sh
+++ b/scripts/export_sms_feed.sh
@@ -9,6 +9,8 @@
 #	<sms-host>    Hostname of SMS box to log into. (E.g. root@example.com)
 #	<base-url>    Base URL of SMS archive endpoint.
 #	              (E.g. http://user:pass@download.example.com:1234/archive)
+#	<base-image-url>    Base URL of SMS thumbnail images.
+#	              (E.g. https://sms.cam.ac.uk/image/)
 #	<file>        File to write feed to or "-" for stdout
 #	<csv>         If specified, write CSV to this file.
 #
@@ -21,11 +23,12 @@ set -e
 
 HOST=$1
 BASE=$2
-FEED=$3
-CSV=$4
+BASE_IMAGE_URL=$3
+FEED=$4
+CSV=$5
 
 if [ -z "${FEED}" ]; then
-	echo "usage: export_sms_feed <sms-host> <base-url> <feed> [<csv>]" >&2
+	echo "usage: export_sms_feed <sms-host> <base-url> <base-image-url> <feed> [<csv>]" >&2
 	exit 1
 fi
 
@@ -64,7 +67,7 @@ COPY (
 		m.visibility AS visibility,
 		m.acl AS acl,
 		m.screencast AS screencast,
-		m.image_id AS image_id,
+		coalesce(m.image_id, sms_collection.image_id) AS image_id,
 		m.dspace_path AS dspace_path,
 		m.featured AS featured,
 		m.branding AS branding,
@@ -88,7 +91,7 @@ COPY (
 EOL
 
 msg "-- Generating feed"
-sms2jwplayer -v genmrss --base="${BASE}" --output=feed.rss \
+sms2jwplayer -v genmrss --base="${BASE}" --base-image-url="${BASE_IMAGE_URL}" --output=feed.rss \
 	${EXTRA_GENMRSS_OPTS} sms_export.csv
 
 popd >/dev/null

--- a/sms2jwplayer/__init__.py
+++ b/sms2jwplayer/__init__.py
@@ -3,7 +3,7 @@ Tool to support bulk import of University of Cambridge SMS into JWPlayer.
 
 Usage:
     sms2jwplayer (-h | --help)
-    sms2jwplayer genmrss [--verbose] --base=URL [--strip-leading=N]
+    sms2jwplayer genmrss [--verbose] --base=URL --base-image-url=URL [--strip-leading=N]
         [--output=FILE] [--limit=NUMBER] [--offset=NUMBER] <csv>
     sms2jwplayer fetch [--verbose] [--base-name=NAME]
     sms2jwplayer genupdatejob [--verbose] [--strip-leading=N]
@@ -26,6 +26,7 @@ Options:
     --output=FILE       Output file. If omitted, use stdout.
 
     --base=URL          Base URL to use for links in MRSS feed.
+    --base-image-url=URL          Base URL to use for thumbnail images in MRSS feed.
     --strip-leading=N   Number of leading components of filename path to strip
                         from filenames in the CSV. [default: 1]
 
@@ -45,7 +46,6 @@ Sub commands:
 
 """
 import logging
-
 import docopt
 
 

--- a/sms2jwplayer/test/test_genmrss.py
+++ b/sms2jwplayer/test/test_genmrss.py
@@ -21,7 +21,8 @@ class BasicCallTest(unittest.TestCase):
     """
     def test_basic_call(self):
         """Calling genmrss with example csv does not throw."""
-        genmrss('--base=http://example.com/', data_path('export_example.csv'))
+        genmrss('--base=http://example.com/', '--base-image-url=http://example.com/images/',
+                data_path('export_example.csv'))
 
     def test_file_output(self):
         """
@@ -32,7 +33,7 @@ class BasicCallTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             csv_out = os.path.join(td, 'out.csv')
             genmrss(
-                '--base=http://example.com/',
+                '--base=http://example.com/', '--base-image-url=http://example.com/images/',
                 '--output=' + csv_out,
                 data_path('export_example.csv'),
             )
@@ -49,7 +50,8 @@ class BasicCallTest(unittest.TestCase):
         """
         with captured_stdout() as stdout:
             genmrss(
-                '--base=http://example.com/', data_path('export_example.csv')
+                '--base=http://example.com/', '--base-image-url=http://example.com/images/',
+                data_path('export_example.csv')
             )
 
         # Check some output was written
@@ -63,7 +65,8 @@ class MRSSFormatTests(unittest.TestCase):
     def setUp(self):
         with captured_stdout() as stdout:
             genmrss(
-                '--base=' + self.BASE_URL, data_path('export_example.csv')
+                '--base=' + self.BASE_URL, '--base-image-url=http://example.com/images/',
+                data_path('export_example.csv')
             )
 
         # Store raw and parsed output


### PR DESCRIPTION
- Modified the export_sms_feed.sh to use the media image_id or in its absence its collection image_id
- Added a new command line parameter for "base-image-url" that will be used as the base URL where the images are being served (same as "base" for videos)

Closes https://github.com/uisautomation/sms-webapp/issues/36