### PR TITLE
BUGFIX: Wrong media type imported

### DIFF
--- a/sms2jwplayer/analytics.py
+++ b/sms2jwplayer/analytics.py
@@ -37,7 +37,7 @@ import requests
 import tqdm
 
 from .util import get_jwplatform_client, JWPlatformClientError
-from jwplatform.errors import JWPlatformRateLimitExceededError
+from jwplatform.errors import JWPlatformRateLimitExceededError, JWPlatformNotFoundError
 
 LOG = logging.getLogger()
 
@@ -138,7 +138,12 @@ def write_output(fobj, client, rows_iterable):
     for row in rows_iterable:
         for _ in range(MAX_ATTEMPTS):
             try:
-                response = client.videos.show(video_key=row.media_id)
+                try:
+                    response = client.videos.show(video_key=row.media_id)
+                except JWPlatformNotFoundError:
+                    # the video could have been deleted
+                    break
+
                 if not response.get('status') == 'ok':
                     break
 

--- a/sms2jwplayer/applyupdatejob.py
+++ b/sms2jwplayer/applyupdatejob.py
@@ -114,11 +114,13 @@ def videos_insert(client, delay, resource):
     """Inserts a video into a channel and updates the custom sms_media_ids param to reflect
     the new state of the channel."""
     try:
-        video_key = util.key_for_clip_id(resource['clip_id'])
+        video_key = util.key_for_media_id(resource['media_id'])
         time.sleep(delay)
     except util.VideoNotFoundError:
-        return 'video not found for clip_id: {}'.format(resource['clip_id'])
-    channel = util.channel_for_collection_id(resource['collection_id'], client)
+        return 'video not found for media_id: {}'.format(resource['media_id'])
+    channel = util.resource_for_entity_id(
+        'channels', 'collection', resource['collection_id'], client
+    )
     time.sleep(delay)
     if not channel:
         return 'channel not found for collection_id: {}'.format(resource['collection_id'])
@@ -148,11 +150,13 @@ def videos_delete(client, delay, resource):
     """Deletes a video from a channel and updates the custom sms_media_ids param to reflect
     the new state of the channel."""
     try:
-        video_key = util.key_for_clip_id(resource['clip_id'])
+        video_key = util.key_for_media_id(resource['media_id'])
         time.sleep(delay)
     except util.VideoNotFoundError:
-        return 'video not found for clip_id: ' + resource['clip_id']
-    channel = util.channel_for_collection_id(resource['collection_id'], client)
+        return 'video not found for media_id: {}'.format(resource['media_id'])
+    channel = util.resource_for_entity_id(
+        'channels', 'collection', resource['collection_id'], client
+    )
     time.sleep(delay)
     if not channel:
         return 'channel not found for collection_id: ' + resource['collection_id']

--- a/sms2jwplayer/applyupdatejob.py
+++ b/sms2jwplayer/applyupdatejob.py
@@ -114,10 +114,10 @@ def videos_insert(client, delay, resource):
     """Inserts a video into a channel and updates the custom sms_media_ids param to reflect
     the new state of the channel."""
     try:
-        video_key = util.key_for_media_id(resource['media_id'])
+        video_key = util.key_for_clip_id(resource['clip_id'])
         time.sleep(delay)
     except util.VideoNotFoundError:
-        return 'video not found for media_id: {}'.format(resource['media_id'])
+        return 'video not found for clip_id: {}'.format(resource['clip_id'])
     channel = util.channel_for_collection_id(resource['collection_id'], client)
     time.sleep(delay)
     if not channel:
@@ -148,10 +148,10 @@ def videos_delete(client, delay, resource):
     """Deletes a video from a channel and updates the custom sms_media_ids param to reflect
     the new state of the channel."""
     try:
-        video_key = util.key_for_media_id(resource['media_id'])
+        video_key = util.key_for_clip_id(resource['clip_id'])
         time.sleep(delay)
     except util.VideoNotFoundError:
-        return 'video not found for media_id: ' + resource['media_id']
+        return 'video not found for clip_id: ' + resource['clip_id']
     channel = util.channel_for_collection_id(resource['collection_id'], client)
     time.sleep(delay)
     if not channel:
@@ -205,7 +205,7 @@ def create_calls(client, creates):
             params = resource_to_params(resource)
 
             # We wrap the entire create/update process in a function since we make use of two API
-            # calls (one is via key_for_media_id). Hence we want to re-try the entire thing if we
+            # calls (one is via key_for_clip_id). Hence we want to re-try the entire thing if we
             # hit the API rate limit.
             def do_create(delay):
                 # If video_key is set to anything other than None, an update of that video key will
@@ -213,27 +213,27 @@ def create_calls(client, creates):
                 video_key = None
 
                 # See if the resource already exists. If so, perform an update instead.
-                media_id_prop = params.get('custom.sms_media_id')
-                if media_id_prop is not None:
+                clip_id_prop = params.get('custom.sms_clip_id')
+                if clip_id_prop is not None:
                     try:
-                        media_id = int(util.parse_custom_prop('media', media_id_prop))
+                        clip_id = int(util.parse_custom_prop('clip', clip_id_prop))
                     except ValueError:
-                        LOG.warning('Skipping video with bad media id prop: %s', media_id_prop)
+                        LOG.warning('Skipping video with bad clip id prop: %s', clip_id_prop)
                     else:
-                        # Attempt to find a matching video for this media id.
+                        # Attempt to find a matching video for this clip id.
                         # If None found, that's OK.
                         try:
-                            video_key = util.key_for_media_id(media_id)
+                            video_key = util.key_for_clip_id(clip_id)
                         except util.VideoNotFoundError:
                             pass
                         finally:
                             time.sleep(delay)
 
                 if video_key is not None:
-                    LOG.warning('Updating video %(video_key)s instead of creating new one',
-                                {'video_key': video_key})
-                    return client.videos.update(
-                        http_method='POST', video_key=video_key, **params)
+                    LOG.warning(
+                        'Video %(video_key)s already exists - not creating',
+                        {'video_key': video_key}
+                    )
                 else:
                     return client.videos.create(http_method='POST', **params)
 
@@ -243,8 +243,8 @@ def create_calls(client, creates):
             params = resource_to_params(resource)
 
             # We wrap the entire create/update process in a function since we make use of two API
-            # calls (one is via key_for_media_id). Hence we want to re-try the entire thing if we
-            # hit the API rate limit.
+            # calls (one is via key_for_collection_id). Hence we want to re-try the entire thing
+            # if we hit the API rate limit.
             def do_create(delay):
                 # If channel_key is set to anything other than None, an update of that channel key
                 # will be done instead.

--- a/sms2jwplayer/genupdatejob.py
+++ b/sms2jwplayer/genupdatejob.py
@@ -248,24 +248,27 @@ def process_videos(opts, fobj, items, videos):
                 'type': 'videos',
                 'resource': update_job,
             })
-            if item.image_md5:
-                image_status = get_key_path(video, 'custom.sms_image_status')
-                image_md5_changed = 'sms_image_md5' in delta.get('custom', {})
-                # We want to trigger an upload of an image in the following circumstances:
-                #   - The MD5s do not match *and* there is not an upload currently in progress
-                md5_mismatch = image_md5_changed and image_status != 'image_status:loaded:'
-                #   - The MD5s match but the matching upload was never attempted
-                no_upload = not image_md5_changed and not image_status
-                if md5_mismatch or no_upload:
-                    # there is an SMS image and JWPlayer image MD5 either doesn't exist
-                    # or doesn't match it - so we need to load the image
-                    updates.append({
-                        'type': 'image_load',
-                        'resource': {
-                            'video_key': video['key'], 'image_url': image_url(opts, item)
-                        },
-                    })
 
+        # decision on creating image_load job
+        if item.image_md5:
+            image_status = get_key_path(video, 'custom.sms_image_status')
+            image_md5_changed = 'sms_image_md5' in delta.get('custom', {})
+            # We want to trigger an upload of an image in the following circumstances:
+            #   - The MD5s do not match *and* there is not an upload currently in progress
+            md5_mismatch = image_md5_changed and image_status != 'image_status:loaded:'
+            #   - The MD5s match but the matching upload was never attempted
+            no_upload = not image_md5_changed and not image_status
+            if md5_mismatch or no_upload:
+                # there is an SMS image and JWPlayer image MD5 either doesn't exist
+                # or doesn't match it - so we need to load the image
+                updates.append({
+                    'type': 'image_load',
+                    'resource': {
+                        'video_key': video['key'], 'image_url': image_url(opts, item)
+                    },
+                })
+
+        # decision on creating image_check job
         if item.image_md5 and video['custom'].get('sms_image_status') == 'image_status:loaded:':
             # there is an SMS image and the image has been loaded but needs to be checked
             updates.append({'type': 'image_check', 'resource': {'video_key': video['key']}})

--- a/sms2jwplayer/test/data/export_example.csv
+++ b/sms2jwplayer/test/data/export_example.csv
@@ -1,4 +1,3 @@
 media_id,clip_id,format,filename,created_at,title,description,collection_id,instid,aspect_ratio,creator,publisher,copyright,language,keywords,visibility,acl,screencast,image_id,image_md5,featured,branding,last_updated_at,updated_by,downloadable,withdrawn
 8,997042,archive-h264,/archive/8/997042.mp4,2007-09-04 19:11:47+01,foo,foobar,12,SB,4x3,spqr2,,,,,world,,f,,,t,f,2007-09-04 19:11:48+01,spqr2,f,
 8,13264,audio,/archive/8/13264.aif,2007-09-04 19:11:47+01,some title,and some description,12,SB,16x9,spqr2,,,,,world,,f,,,t,f,2007-09-04 19:11:47+01,spqr2,f,
-g.s

--- a/sms2jwplayer/test/test_util.py
+++ b/sms2jwplayer/test/test_util.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from io import StringIO
 
-from sms2jwplayer.util import upload_thumbnail_from_url, channel_for_collection_id
+from sms2jwplayer.util import upload_thumbnail_from_url, resource_for_entity_id
 
 from .util import JWPlatformTestCase
 
@@ -64,7 +64,7 @@ class UtilTests(JWPlatformTestCase):
             files={'file': urlopen.return_value}
         )
 
-    def test_channel_for_collection_id__success(self):
+    def test_resource_for_entity_id__success(self):
         """Test that a channel is found"""
 
         self.client.channels.list.return_value = {
@@ -72,7 +72,7 @@ class UtilTests(JWPlatformTestCase):
             'channels': [CHANNEL_FIXTURE]
         }
 
-        channel = channel_for_collection_id(123, client=self.client)
+        channel = resource_for_entity_id('channels', 'collection', 123, client=self.client)
 
         self.assertEquals(channel, CHANNEL_FIXTURE)
 
@@ -80,7 +80,7 @@ class UtilTests(JWPlatformTestCase):
             'search:custom.sms_collection_id': 'collection:123:',
         })
 
-    def test_channel_for_collection_id__no_channel(self):
+    def test_resource_for_entity_id__no_channel(self):
         """Test that no channel is found"""
 
         self.client.channels.list.return_value = {
@@ -88,9 +88,11 @@ class UtilTests(JWPlatformTestCase):
             'channels': []
         }
 
-        self.assertIsNone(channel_for_collection_id(123, client=self.client))
+        self.assertIsNone(
+            resource_for_entity_id('channels', 'collection', 123, client=self.client)
+        )
 
-    def test_channel_for_collection_id__2_channels(self):
+    def test_resource_for_entity_id__2_channels(self):
         """Test that if 2 channels are found - one is returned and a warning is logged"""
 
         channel_2 = dict(CHANNEL_FIXTURE)
@@ -102,9 +104,9 @@ class UtilTests(JWPlatformTestCase):
         }
 
         with self.assertLogs() as logs:
-            channel = channel_for_collection_id(123, client=self.client)
+            channel = resource_for_entity_id('channels', 'collection', 123, client=self.client)
             self.assertEqual(logs.output, [
-                'WARNING:sms2jwplayer.util:Collection 123 matches more than one channel'
+                'WARNING:sms2jwplayer.util:collection 123 matches at least 2 channels'
             ])
 
         self.assertEquals(channel, CHANNEL_FIXTURE)


### PR DESCRIPTION
Addresses the bug where the wrong media type is uploaded to JWPlatform for an SMS media item. It was indeterminate which media item clip (video or audio) was chosen (for instance it was wrong on transcode1 but right when testing in developement). To be honest, I'm not exactly sure what root cause was, but seeing as the code supported a 2 to 1 mapping which was no longer required, I simplified the code to just support a 1 to 1 mapping (same as for collections), which seems to have done the trick.

In addition to this - the last 2 commits address 2 different, but equally important bugs:
1. If a video was played and deleted on the same day, this caused an error in the analytics module.
2. No image_load or image_check jobs were being generated due to faulty indentation (!)
