### PR TITLE
genupdatejob: make sanitize a little more forgiving

### DIFF
--- a/sms2jwplayer/genupdatejob.py
+++ b/sms2jwplayer/genupdatejob.py
@@ -477,14 +477,13 @@ def image_url(opts, item):
     return urllib.parse.urljoin(opts['--base-image-url'], str(item.image_id))
 
 
-def sanitise(s, max_length=4096):
+def sanitise(s):
     """
-    Strip odd characters from a string and sanitise the length to avoid JWPlatform complaining.
+    Strip odd characters from a string if JWPlatform complains.
 
     """
     # Map control characters to empty string
-    s = s.translate(dict.fromkeys(range(32)))
-
-    # Truncate
-    s = s[:max_length]
+    ctrl_char_map = dict.fromkeys(range(32))
+    del ctrl_char_map[10]  # allow newlines
+    s = s.translate(ctrl_char_map)
     return s


### PR DESCRIPTION
Initially we had to truncate video descriptions because the JWP client libraries would try to pass all parameters as GET requests, even when using HTTP POST. That has been fixed by later versions of the JWP client. Additionally, we want to allow for newlines in descriptions since they are usually important.

Update the sanitisiation function to only strip non-newline control characters and to no-longer truncate strings.