### PR TITLE
widen range of acceptable export formats

### DIFF
--- a/scripts/export_sms_csv.sh
+++ b/scripts/export_sms_csv.sh
@@ -64,16 +64,13 @@ COPY (
         m.last_updated AS last_updated_at,
         m.updated_by AS updated_by,
         m.downloadable AS downloadable,
-        m.withdrawn AS withdrawn
+        m.withdrawn AS withdrawn,
+        sms_clip.quality AS quality
     FROM
         sms_media m
         JOIN sms_clip ON sms_clip.media_id = m.id
         JOIN sms_collection ON sms_collection.id = m.collection_id
         LEFT OUTER JOIN sms_image i on i.id = coalesce(m.image_id, sms_collection.image_id)
-    WHERE
-        ( sms_clip.format = 'archive-h264' OR sms_clip.format = 'audio' )
-        AND sms_clip.quality = 'high'
-        AND sms_clip.filename IS NOT NULL
     ORDER BY
         m.id
 ) TO STDOUT DELIMITER ',' CSV HEADER;

--- a/sms2jwplayer/__init__.py
+++ b/sms2jwplayer/__init__.py
@@ -31,7 +31,7 @@ Options:
     --base=URL          Base URL to use for links in MRSS feed.
     --base-image-url=URL          Base URL to use for thumbnail images in MRSS feed.
     --strip-leading=N   Number of leading components of filename path to strip
-                        from filenames in the CSV. [default: 1]
+                        from filenames in the CSV. [default: 0]
 
     --base-name=NAME    Base of filename used to save results to.
                         [default: videos_]

--- a/sms2jwplayer/csv.py
+++ b/sms2jwplayer/csv.py
@@ -67,6 +67,25 @@ CollectionItem._ITEM_TYPES = [
 class MediaFormat(enum.Enum):
     VIDEO = 'archive-h264'
     AUDIO = 'audio'
+    AAC = 'aac'
+    AIFF = 'aiff'
+    FLV = 'flv'
+    IPOD = 'ipod'
+    MOV = 'mov'
+    MP3 = 'mp3'
+    MPEG4 = 'mpeg4'
+    RA = 'ra'
+    RM = 'rm'
+    WEBM = 'webm'
+    WMV = 'wmv'
+
+
+class MediaQuality(enum.Enum):
+    LOW_RES = '360p'
+    HIGH_RES = '720p'
+    HIGH = 'high'
+    LOW = 'low'
+    MEDIUM = 'medium'
 
 
 MediaItem = collections.namedtuple(
@@ -75,7 +94,7 @@ MediaItem = collections.namedtuple(
                   'creator publisher copyright language keywords visibility '
                   'acl screencast image_id image_md5 '
                   'featured branding last_updated_at updated_by '
-                  'downloadable withdrawn')
+                  'downloadable withdrawn quality')
 )
 MediaItem.__doc__ = """
 Representation of a single media item within the SMS.
@@ -159,6 +178,8 @@ same but prefixed by "`sms_`".
 * ``downloadable`` - Whether or not the media item can be downloaded from it's page.
 
 * ``withdrawn`` - No definition available.
+
+* ``quality`` - The quality of the encoded video. E.g. "high", "720p".
 """
 
 # Callables which massage strings into the right types for each column
@@ -168,7 +189,7 @@ MediaItem._ITEM_TYPES = [
     str, str, str, str, str, str,
     lambda acl: acl.split(','), lambda b: b == 't', lambda i: int(i) if i != '' else None, str,
     lambda b: b == 't', lambda b: b == 't', dateutil.parser.parse, str,
-    lambda b: b == 't', str
+    lambda b: b == 't', str, MediaQuality
 ]
 
 

--- a/sms2jwplayer/test/data/export_example.csv
+++ b/sms2jwplayer/test/data/export_example.csv
@@ -1,3 +1,3 @@
-media_id,clip_id,format,filename,created_at,title,description,collection_id,instid,aspect_ratio,creator,publisher,copyright,language,keywords,visibility,acl,screencast,image_id,image_md5,featured,branding,last_updated_at,updated_by,downloadable,withdrawn
-8,997042,archive-h264,/archive/8/997042.mp4,2007-09-04 19:11:47+01,foo,foobar,12,SB,4x3,spqr2,,,,,world,,f,,,t,f,2007-09-04 19:11:48+01,spqr2,f,
-8,13264,audio,/archive/8/13264.aif,2007-09-04 19:11:47+01,some title,and some description,12,SB,16x9,spqr2,,,,,world,,f,,,t,f,2007-09-04 19:11:47+01,spqr2,f,
+media_id,clip_id,format,filename,created_at,title,description,collection_id,instid,aspect_ratio,creator,publisher,copyright,language,keywords,visibility,acl,screencast,image_id,image_md5,featured,branding,last_updated_at,updated_by,downloadable,withdrawn,quality
+8,997042,archive-h264,/archive/8/997042.mp4,2007-09-04 19:11:47+01,foo,foobar,12,SB,4x3,spqr2,,,,,world,,f,,,t,f,2007-09-04 19:11:48+01,spqr2,f,,high
+8,13264,audio,/archive/8/13264.aif,2007-09-04 19:11:47+01,some title,and some description,12,SB,16x9,spqr2,,,,,world,,f,,,t,f,2007-09-04 19:11:47+01,spqr2,f,,high


### PR DESCRIPTION
> **IMPORTANT** This is tested locally with development but has not been deployed. Deployment needs to happen at the same time as uisautomation/sms-ansible#14 otherwise video upload will break. Deployment of sms2jwplayer is currently manual so you'll need to actually log into the box and type "git pull" like a caveman. 

Widen the range of formats we try to upload to JWP. Some media items had neither an audio or video archive export.

Modify the CSV dump script to dump *all* clips and define a preferred ordering for formats, video then audio and within each decreasing quality options. Explicitly log items with no media at all (there are some!) or ones where we could not determine a "best" format.

IMPORTANT: This changes the default strip-leading path option from 1 to 0 to allow for non-archive media items to be downloaded. This needs to be combined with a change to gen_jwplayer_feed.sh to strip the "sms-archive02/" from the base URL.