### PR TITLE
use media id as primary key when determining create/update

### DIFF
--- a/sms2jwplayer/applyupdatejob.py
+++ b/sms2jwplayer/applyupdatejob.py
@@ -209,7 +209,7 @@ def create_calls(client, creates):
             params = resource_to_params(resource)
 
             # We wrap the entire create/update process in a function since we make use of two API
-            # calls (one is via key_for_clip_id). Hence we want to re-try the entire thing if we
+            # calls (one is via key_for_media_id). Hence we want to re-try the entire thing if we
             # hit the API rate limit.
             def do_create(delay):
                 # If video_key is set to anything other than None, an update of that video key will
@@ -217,17 +217,17 @@ def create_calls(client, creates):
                 video_key = None
 
                 # See if the resource already exists. If so, perform an update instead.
-                clip_id_prop = params.get('custom.sms_clip_id')
-                if clip_id_prop is not None:
+                media_id_prop = params.get('custom.sms_media_id')
+                if media_id_prop is not None:
                     try:
-                        clip_id = int(util.parse_custom_prop('clip', clip_id_prop))
+                        media_id = int(util.parse_custom_prop('media', media_id_prop))
                     except ValueError:
-                        LOG.warning('Skipping video with bad clip id prop: %s', clip_id_prop)
+                        LOG.warning('Skipping video with bad media id prop: %s', media_id_prop)
                     else:
-                        # Attempt to find a matching video for this clip id.
+                        # Attempt to find a matching video for this media id.
                         # If None found, that's OK.
                         try:
-                            video_key = util.key_for_clip_id(clip_id)
+                            video_key = util.key_for_media_id(media_id)
                         except util.VideoNotFoundError:
                             pass
                         finally:

--- a/sms2jwplayer/genupdatejob.py
+++ b/sms2jwplayer/genupdatejob.py
@@ -276,7 +276,7 @@ def process_videos(opts, fobj, items, videos):
 
         return updates
 
-    generic_job_creator(fobj, 'clip', items, videos, create, update)
+    generic_job_creator(fobj, 'media', items, videos, create, update)
 
 
 def choose_media_format(items):

--- a/sms2jwplayer/util.py
+++ b/sms2jwplayer/util.py
@@ -120,28 +120,6 @@ class VideoNotFoundError(RuntimeError):
     """
 
 
-def key_for_clip_id(clip_id, client=None):
-    """
-    :param clip_id: clip id of the SMS item to match the JWPlatform video
-    :param client: (options) an authenticated JWPlatform client as returned by
-        :py:func:`.get_jwplatform_client`. If ``None``, call :py:func:`.get_jwplatform_client`.
-    :raises: :py:class:`.VideoNotFoundError`
-        if the clip id does not correspond to a JWPlatform video.
-    :return: The key of a JWPlatform video matching the clip id
-    """
-    video = resource_for_entity_id('videos', 'clip', clip_id, client)
-
-    # If no channel found, raise error
-    if video is None:
-        raise VideoNotFoundError()
-
-    # Check the channel we found has a non-None key
-    if video.get('key') is None:
-        raise VideoNotFoundError()
-
-    return video['key']
-
-
 def key_for_media_id(media_id, client=None):
     """
     :param media_id: media id of the SMS item to match the JWPlatform video


### PR DESCRIPTION
> This has temporarily been deployed to transcode1 and has been tested. It no longer uploads 800-odd new videos for no good reason.

We previously used the clip id as a primary key for determining if a video needed to be updated or created. Unfortunately this meant that our previous change which modified our clip id selection resulted in duplicate videos being uploaded with the same media id and differing clip id.

Compounding this error was the fact that these videos had identical publication dates set which meant that, in practice, they came back from the JWP API in a semi-random order depending on the vagaries of their database.

Move to using media id as the primary key which should stop this happening in future. We still need to tidy up the videos in JWP. The best approach would be to simply delete all the videos with multiple clip ids.