### PR TITLE
Add clause to export_sms_csv.sh that excludes corrupted clips

### DIFF
--- a/scripts/export_sms_csv.sh
+++ b/scripts/export_sms_csv.sh
@@ -71,6 +71,7 @@ COPY (
         JOIN sms_clip ON sms_clip.media_id = m.id
         JOIN sms_collection ON sms_collection.id = m.collection_id
         LEFT OUTER JOIN sms_image i on i.id = coalesce(m.image_id, sms_collection.image_id)
+    WHERE NOT EXISTS (SELECT * FROM corrupted_clips WHERE corrupted_clips.clip_id = sms_clip.id)
     ORDER BY
         m.id
 ) TO STDOUT DELIMITER ',' CSV HEADER;


### PR DESCRIPTION
It appears that there are a small number of original archived sources in SMS that are corrupted. The table `corrupted_clips` has been created and populated with the clip ids of these sources. This PR adds a SQL clause to `export_sms_csv.sh` that excludes these clips. This will allow one of the other transcoded sources to be tried instead.

related to: uisautomation/media-webapp/issues/225
